### PR TITLE
feat: register option의 value 유무에 따라 input 동작 방식 결정

### DIFF
--- a/src/hooks/Form/useForm.ts
+++ b/src/hooks/Form/useForm.ts
@@ -125,6 +125,10 @@ const useForm = <DefaultValues extends FormFields>(options?: UseFormOptions<Defa
       onBlur?(e: ChangeEvent<HTMLInputElement | HTMLSelectElement>): void;
     },
   ) => {
+    const isControlledValue = options?.value !== undefined;
+
+    const controlledValue = parseToInputValue(options?.value);
+
     const onChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
       const {
         target: { value },
@@ -148,14 +152,17 @@ const useForm = <DefaultValues extends FormFields>(options?: UseFormOptions<Defa
     const ref: RefCallback<HTMLInputElement | HTMLSelectElement> = instance => {
       if (!instance) return;
 
-      /**@todo need? */
-      instance.value = getFieldValue(name);
+      if (!getFieldInfo(name)?.registered) {
+        const defaultValue = getFieldValue(name);
 
       registerField(name, {
-        value: parseToInputValue(options?.value),
+          value: controlledValue || defaultValue,
         validations: options?.validations,
         ref: instance,
       });
+
+        instance.value = getFieldValue(name);
+      }
     };
 
     return {
@@ -163,6 +170,7 @@ const useForm = <DefaultValues extends FormFields>(options?: UseFormOptions<Defa
       onChange,
       onBlur,
       ref,
+      ...(isControlledValue ? { value: controlledValue } : {}),
     };
   };
 

--- a/src/utils/formStore/createFormStore.ts
+++ b/src/utils/formStore/createFormStore.ts
@@ -61,7 +61,7 @@ const createFormsStore = <DefaultValues extends FormFields>(
     store[name] = {
       ...store[name],
       ...options,
-      value: store[name]?.registered ? store[name]?.value : parseToInputValue(options?.value),
+      value: parseToInputValue(options?.value),
       registered: true,
     };
   };


### PR DESCRIPTION
- register option의 value를 적용하는 경우 controlled input으로 동작한다.(onChange와 함께 사용해야 한다.)

- register option의 value를 적용하지 않는 경우 uncontrolled input으로 동작한다.(구독하지 않으면 리렌더링이 발생하지 않는다.)